### PR TITLE
Methods for apply, delete and get

### DIFF
--- a/example-service.json
+++ b/example-service.json
@@ -1,0 +1,12 @@
+{
+	"type": "service",
+	"list": [
+		{
+			"id": "1",
+			"name": "nginx1",
+			"image": "nginx:latest",
+			"replicas": 1,
+			"memoryLimit": 32
+		}		
+	]
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/plancks-cloud/plancks-cli
 
-require github.com/sirupsen/logrus v1.3.0
+require (
+	github.com/sirupsen/logrus v1.3.0
+	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/plancks-cloud/plancks-cli
+
+require github.com/sirupsen/logrus v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.3.0 h1:hI/7Q+DtNZ2kINb6qt/lS+IyXnHQe9e90POfeewL/ME=
+github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/sirupsen/logrus v1.3.0 h1:hI/7Q+DtNZ2kINb6qt/lS+IyXnHQe9e90POfeewL/ME
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 h1:BP2bjP495BBPaBcS5rmqviTfrOkN5rO5ceKAMRZCRFc=
+github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=

--- a/pccli.go
+++ b/pccli.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"errors"
-	"flag"
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -118,37 +117,6 @@ func split(in string) (f, v string, err error) {
 	s := strings.Split(in, "=")
 	f, v = s[0], s[1]
 	return
-}
-
-func main2() {
-	//Actions
-	apply := flag.Bool("apply", false, "Apply a file")
-
-	//General
-	saveEndpoint := flag.Bool("save-endpoint", false, "Whether or not to save the url to file.")
-	endpoint := flag.String("endpoint", "http://127.0.0.1:6227", "Endpoint of the PC API server.")
-
-	//Specific
-	file := flag.String("file", "", "Json file to apply.")
-
-	flag.Parse()
-	fmt.Printf("apply: %v, saveEndpoint: %v, file: %s, endpoint: %s\n", *apply, *saveEndpoint, *file, *endpoint)
-
-	//TODO: lots of checking....
-
-	//TODO: persist to file
-	if *saveEndpoint {
-		//Where to save?
-		//runtime.GOOS
-	}
-
-	//Route the action
-	if *apply {
-		handleApply(endpoint, file)
-	} else {
-		panic("Nothing to do!")
-	}
-
 }
 
 func handleApply(endpoint, file *string) {

--- a/pccli.go
+++ b/pccli.go
@@ -62,6 +62,7 @@ func main() {
 
 	if delete {
 		handleDelete(&endpoint, &filename)
+		return
 	}
 
 	if get {

--- a/pccli.go
+++ b/pccli.go
@@ -2,15 +2,125 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 )
 
+//Commands
+var apply bool
+var delete bool
+var get bool
+
+//Flags
+var filename string
+var endpoint string
+var object string
+
 func main() {
+	err := readFirst()
+	if err != nil {
+		logrus.Error(err)
+		return
+	}
+	readFlags()
+
+	if !apply && !delete {
+		logrus.Error(errors.New("No command. Supported commands are apply, delete."))
+		return
+	}
+
+	if !apply && !delete {
+		logrus.Error(errors.New("No command. Supported commands are apply, delete."))
+		return
+	}
+
+	//TODO: load filename if "" from .plancks in ~/
+
+	if (filename == "" && apply) || (filename == "" && delete) {
+		logrus.Error(errors.New("No filename for command"))
+		return
+	}
+
+	if (endpoint == "" && apply) || (endpoint == "" && delete) {
+		endpoint = "127.0.0.1:6227"
+		logrus.Println("Assuming endpoint 127.0.0.1:6227")
+	}
+
+	/// End of checking
+
+	if apply {
+		handleApply(&endpoint, &filename)
+		return
+	}
+
+	if delete {
+		handleDelete(&endpoint, &filename)
+	}
+
+	if get {
+		//TODO
+	}
+
+}
+
+func readFirst() (err error) {
+	if len(os.Args) < 2 {
+		err = errors.New("Not enough arguments. Provide either apply or delete.")
+		return
+	}
+	if os.Args[1] == "apply" || os.Args[0] == "a" {
+		apply = true
+	} else if os.Args[1] == "delete" || os.Args[0] == "d" {
+		delete = true
+	} else if os.Args[1] == "get" || os.Args[0] == "g" {
+		get = true
+	}
+	return
+}
+
+func readFlags() {
+	for i, s := range os.Args {
+		if i < 2 {
+			continue
+		}
+		f, v, e := split(s)
+		if e != nil {
+			continue
+		}
+		if f == "-f" || f == "-filename" {
+			filename = v
+			continue
+		}
+		if f == "-e" || f == "-endpoint" {
+			endpoint = v
+			continue
+		}
+		if f == "-o" || f == "-object" {
+			endpoint = v
+			continue
+		}
+	}
+}
+
+func split(in string) (f, v string, err error) {
+	if !strings.Contains(in, "=") {
+		err = errors.New("No value")
+		return
+	}
+	s := strings.Split(in, "=")
+	f, v = s[0], s[1]
+	return
+}
+
+func main2() {
 	//Actions
 	apply := flag.Bool("apply", false, "Apply a file")
 
@@ -50,6 +160,36 @@ func handleApply(endpoint, file *string) {
 	client.Timeout = time.Second * 5
 
 	uri := fmt.Sprint(*endpoint, "/apply")
+	body := bytes.NewBuffer(b)
+	req, err := http.NewRequest(http.MethodPut, uri, body)
+	if err != nil {
+		log.Fatalf("http.NewRequest() failed with '%s'\n", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("client.Do() failed with '%s'\n", err)
+	}
+
+	defer resp.Body.Close()
+	b, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("ioutil.ReadAll() failed with '%s'\n", err)
+	}
+
+	fmt.Printf("Response status code: %d, text:\n%s\n", resp.StatusCode, string(b))
+}
+
+func handleDelete(endpoint, file *string) {
+	b, err := ioutil.ReadFile(*file)
+	if err != nil {
+		log.Fatalf("Failed to read file %s: '%s'\n", *file, err)
+	}
+	client := &http.Client{}
+	client.Timeout = time.Second * 5
+
+	uri := fmt.Sprint(*endpoint, "/delete")
 	body := bytes.NewBuffer(b)
 	req, err := http.NewRequest(http.MethodPut, uri, body)
 	if err != nil {

--- a/pccli.go
+++ b/pccli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/sirupsen/logrus"
+	"github.com/tidwall/pretty"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -31,13 +32,8 @@ func main() {
 	}
 	readFlags()
 
-	if !apply && !delete {
-		logrus.Error(errors.New("No command. Supported commands are apply, delete."))
-		return
-	}
-
-	if !apply && !delete {
-		logrus.Error(errors.New("No command. Supported commands are apply, delete."))
+	if !apply && !delete && !get {
+		logrus.Error(errors.New("No command. Supported commands are apply, delete, get."))
 		return
 	}
 
@@ -48,9 +44,9 @@ func main() {
 		return
 	}
 
-	if (endpoint == "" && apply) || (endpoint == "" && delete) {
-		endpoint = "127.0.0.1:6227"
-		logrus.Println("Assuming endpoint 127.0.0.1:6227")
+	if (endpoint == "" && apply) || (endpoint == "" && delete) || (endpoint == "" && get) {
+		endpoint = "http://127.0.0.1:6227"
+		logrus.Println("Assuming endpoint http://127.0.0.1:6227")
 	}
 
 	/// End of checking
@@ -105,7 +101,7 @@ func readFlags() {
 			continue
 		}
 		if f == "-o" || f == "-object" {
-			endpoint = v
+			object = v
 			continue
 		}
 	}
@@ -147,8 +143,9 @@ func handleApply(endpoint, file *string) {
 	if err != nil {
 		log.Fatalf("ioutil.ReadAll() failed with '%s'\n", err)
 	}
-
-	fmt.Printf("Response status code: %d, text:\n%s\n", resp.StatusCode, string(b))
+	p := pretty.Pretty(b)
+	p = pretty.Color(p, pretty.TerminalStyle)
+	fmt.Println(string(p))
 }
 
 func handleDelete(endpoint, file *string) {
@@ -177,8 +174,9 @@ func handleDelete(endpoint, file *string) {
 	if err != nil {
 		log.Fatalf("ioutil.ReadAll() failed with '%s'\n", err)
 	}
-
-	fmt.Printf("Response status code: %d, text:\n%s\n", resp.StatusCode, string(b))
+	p := pretty.Pretty(b)
+	p = pretty.Color(p, pretty.TerminalStyle)
+	fmt.Println(string(p))
 }
 
 func handleGet(endpoint, object *string) {
@@ -202,7 +200,8 @@ func handleGet(endpoint, object *string) {
 	if err != nil {
 		log.Fatalf("ioutil.ReadAll() failed with '%s'\n", err)
 	}
-
-	fmt.Printf("Response status code: %d, text:\n%s\n", resp.StatusCode, string(b))
+	p := pretty.Pretty(b)
+	p = pretty.Color(p, pretty.TerminalStyle)
+	fmt.Println(string(p))
 
 }

--- a/pccli.go
+++ b/pccli.go
@@ -73,11 +73,11 @@ func readFirst() (err error) {
 		err = errors.New("Not enough arguments. Provide either apply or delete.")
 		return
 	}
-	if os.Args[1] == "apply" || os.Args[0] == "a" {
+	if os.Args[1] == "apply" || os.Args[1] == "a" {
 		apply = true
-	} else if os.Args[1] == "delete" || os.Args[0] == "d" {
+	} else if os.Args[1] == "delete" || os.Args[1] == "d" {
 		delete = true
-	} else if os.Args[1] == "get" || os.Args[0] == "g" {
+	} else if os.Args[1] == "get" || os.Args[1] == "g" {
 		get = true
 	}
 	return

--- a/pccli.go
+++ b/pccli.go
@@ -66,7 +66,8 @@ func main() {
 	}
 
 	if get {
-		//TODO
+		handleGet(&endpoint, &object)
+		return
 	}
 
 }
@@ -178,4 +179,30 @@ func handleDelete(endpoint, file *string) {
 	}
 
 	fmt.Printf("Response status code: %d, text:\n%s\n", resp.StatusCode, string(b))
+}
+
+func handleGet(endpoint, object *string) {
+	//http://localhost:6227/route
+	client := &http.Client{}
+	client.Timeout = time.Second * 5
+
+	uri := fmt.Sprint(*endpoint, "/", *object)
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		log.Fatalf("http.NewRequest() failed with '%s'\n", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("client.Do() failed with '%s'\n", err)
+	}
+
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("ioutil.ReadAll() failed with '%s'\n", err)
+	}
+
+	fmt.Printf("Response status code: %d, text:\n%s\n", resp.StatusCode, string(b))
+
 }


### PR DESCRIPTION
# Features
- Support for **apply**, **delete** and **get** commands
- Support for -filename, -endpoint and -object
- Defaults route to http://localhost:6227

# Examples
```
go run pccli.go apply -e=http://localhost:6227 -f=example-route.json
go run pccli.go delete -f=example-route.json
go run pccli.go get -o=route
```